### PR TITLE
Unify single- and multiple-version interfaces

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "cordwood",
-  "version": "0.1.2",
+  "version": "0.1.4",
   "authors": [
     "Sumit Arora <sumit@rangle.io>",
     "Varun Vachhar <varun@rangle.io>",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,7 +34,8 @@ gulp.task('lint', function() {
   return gulp.src(srcFiles)
     .pipe(eslint())
     .pipe(eslint.format())
-    .pipe(eslint.failOnError())});
+    .pipe(eslint.failOnError());
+});
 
 
 gulp.task('beautify', function() {
@@ -45,7 +46,7 @@ gulp.task('beautify', function() {
 });
 
 // Testing
-gulp.task('test', [], function (done) {
+gulp.task('test', ['lint'], function (done) {
   karma.start({
     configFile: __dirname + '/tests/karma.conf.js',
     singleRun: true
@@ -55,7 +56,9 @@ gulp.task('test', [], function (done) {
 
 gulp.task('tdd', function (done) {
   karma.start({
-    configFile: __dirname + '/tests/karma.conf.js'
+    configFile: __dirname + '/tests/karma.conf.js',
+    singleRun: false,
+    autoWatch: true
   }, done);
 });
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "karma-sinon": "^1.0.4",
     "karma-wrap-preprocessor": "^0.1.0",
     "mocha": "^2.2.4",
-    "sinon": "^1.14.1"
+    "sinon": "~1.14"
   },
   "dependencies": {
     "ramda": "~0.15.1"

--- a/src/cordwood.js
+++ b/src/cordwood.js
@@ -1,7 +1,6 @@
 'use strict';
 var assetService = require('./asset-service');
 var bootstrap = require('./bootstrap');
-var constants = require('./constants');
 var downloadService = require('./download-service');
 var logger = require('./logger');
 var ui = require('./ui');
@@ -23,9 +22,7 @@ function Cordwood(options) {
   var versionsToFetch = options.versionsToFetch;
 
   (function setup() {
-
     assetService.setup(assetDirectories, cordova.file.dataDirectory);
-
     // Setup the callbacks for bootstrapping the app
     bootstrap.setup(successCallback, errorCallback);
     // If a current version is not available
@@ -33,21 +30,16 @@ function Cordwood(options) {
       version.setCurrent(currentVersion);
     }
 
-    if (multipleVersions) {
-      // Fetch all available versions
-      version.fetchAllVersions({
-        'url': urls.allVersions,
-        'versionsToFetch': versionsToFetch,
-        'successCallback': onFetchAllVersions,
-        'errorCallback': function () {
-          // If Fetch all versions fails then default to refreshing master
-          version.fetchLatestVersion(urls.latestVersion, onFetchLatestVersion);
-        }
-      });
-    } else {
-      // Fetch the latest version number and respond accordingly
-      version.fetchLatestVersion(urls.latestVersion, onFetchLatestVersion);
-    }
+    // Fetch all available versions
+    version.fetchAllVersions({
+      'url': urls.allVersions,
+      'versionsToFetch': versionsToFetch,
+      'successCallback': onFetchAllVersions,
+      'errorCallback': function () {
+        // If Fetch all versions fails then default to refreshing master
+        version.fetchLatestVersion(urls.latestVersion, onFetchLatestVersion);
+      }
+    });
 
   })();
 
@@ -98,10 +90,15 @@ function Cordwood(options) {
    * Success callback for fetching all versions.
    */
   function onFetchAllVersions(versions) {
-    ui.init(versions, function (url) {
-      ui.teardown();
-      version.fetchLatestVersion(url, onFetchLatestVersion);
-    });
+    if (multipleVersions === true) {
+      ui.init(versions, function (url) {
+        ui.teardown();
+        version.fetchLatestVersion(url, onFetchLatestVersion);
+      });
+    } else {
+      urls.initForPr(versions[0].path);
+      version.fetchLatestVersion(urls.latestVersion, onFetchLatestVersion);
+    }
   }
 }
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -25,14 +25,12 @@ function itemContent(item) {
 function generateListItem(item, clickFn) {
   var listItem = document.createElement('li');
   listItem.innerHTML = itemContent(item);
-  listItem.onclick = (function () {
-    return function () {
-      urls.initForPr(item.path);
-      item.latestVersion = urls.latestVersion;
-      // make the result available for testing
-      return clickFn(item.latestVersion);
-    };
-  })();
+  listItem.onclick = function() {
+    urls.initForPr(item.path);
+    item.latestVersion = urls.latestVersion;
+    // make the result available for testing
+    return clickFn(item.latestVersion);
+  };
 
   return listItem;
 }
@@ -111,7 +109,6 @@ function teardown() {
   list.parentNode.removeChild(list);
   _styles.parentNode.removeChild(_styles);
 }
-
 
 module.exports.init = init;
 module.exports.teardown = teardown;

--- a/src/version.js
+++ b/src/version.js
@@ -105,11 +105,13 @@ version.fetchLatestVersion = function (url, callback) {
   };
 
   xhr.onreadystatechange = function () {
+    var newVersion;
     /*eslint-disable eqeqeq */
     if (this.readyState == 4 && this.status == 200) {
+      newVersion = this.response.version;
       /*eslint-enable eqeqeq */
-      version.setUpdated(this.response.version);
-      callback();
+      version.setUpdated(newVersion);
+      callback(newVersion);
     }
   };
 

--- a/tests/version.spec.js
+++ b/tests/version.spec.js
@@ -57,7 +57,7 @@ describe('Version', function() {
       this.server.restore();
     });
 
-    it('should be able to fetch new version', function() {
+    it('should be able to fetch new version', function(done) {
       this.server.respondWith(/\/version\?(\d+)/, function(xhr, id) {
         xhr.response = { version: '1.1.0' };
         xhr.respond(200,
@@ -67,6 +67,7 @@ describe('Version', function() {
 
       version.fetchLatestVersion('/version', function(newVersion) {
         expect(newVersion).to.be.equal('1.1.0');
+        done();
       });
 
     });
@@ -116,7 +117,7 @@ describe('Version', function() {
       this.server.restore();
     });
 
-    it('should be able to fetch all available versions', function() {
+    it('should be able to fetch all available versions', function(done) {
       this.server.respondWith(/\/versions\?(\d+)/, function(xhr, id) {
         xhr.response = mockVersions;
         xhr.respond(200,
@@ -126,6 +127,7 @@ describe('Version', function() {
 
       var successCallback = function (versions) {
         expect(versions).to.deep.equal(mockVersions.branches);
+        done();
       };
 
       version.fetchAllVersions({


### PR DESCRIPTION
- Single-version and multiple-version modes both use versions.json
- Tiny bit of refactoring
- Gulp: add "lint" as a dependncy for "test"